### PR TITLE
Support for XE4 (Fix for e1f047ca55d3a961f47505e30fcf6a06a3775da4)

### DIFF
--- a/Dist/OpenApiHttp.pas
+++ b/Dist/OpenApiHttp.pas
@@ -74,11 +74,14 @@ var
   SourceStream: TStream;
   Content: TBytesStream;
   I: Integer;
+  Url: string;
+  LogId: string;
 begin
   Client := THttpClient.Create;
   try
     Client.OnRedirect := DoRedirect;
-    Request := Client.GetRequest(Self.Method, BuildUrl);
+    Url := BuildUrl();
+    Request := Client.GetRequest(Self.Method, Url);
     if Body <> '' then
       SourceStream := TStringStream.Create(Body, TEncoding.UTF8, False)
     else
@@ -89,10 +92,15 @@ begin
       Request.SourceStream := SourceStream;
       if Assigned(FOnClientCreated) then
        FOnClientCreated(Client, Request);
+      if Assigned(Logger) then
+        LogId := Logger.LogRequest(Self.Method, Url, SourceStream);
+
       Content := TBytesStream.Create;
       try
         Response := Client.Execute(Request, Content);
         Result := THttpRestResponse.Create(Response, Content, Client);
+        if Assigned(Logger) then
+          Logger.LogResponse(Self.Method, Url, LogId, Result);
         Content := nil;
         Client := nil;
       finally

--- a/Dist/OpenApiIndy.pas
+++ b/Dist/OpenApiIndy.pas
@@ -115,6 +115,8 @@ var
   I: Integer;
   RequestBody: TStringStream;
   ResponseBody: TBytesStream;
+  Url: string;
+  LogId: string;
 begin
   Client := TIndyHTTP.Create;
   try
@@ -132,8 +134,13 @@ begin
           Client.Request.CustomHeaders.AddValue(Headers.Names[I], Headers.ValueFromIndex[I]);
         if Assigned(FOnClientCreated) then
           FOnClientCreated(Client);
-        Client.DoRequest(Self.Method, BuildUrl, RequestBody, ResponseBody, []);
+        Url := BuildUrl();
+        if Assigned(Logger) then
+          LogId := Logger.LogRequest(Self.Method, Url, RequestBody);
+        Client.DoRequest(Self.Method, Url, RequestBody, ResponseBody, []);
         Result := TIndyRestResponse.Create(Client, Copy(ResponseBody.Bytes, 0, ResponseBody.Size));
+        if Assigned(Logger) then
+          Logger.LogResponse(Self.Method, Url, LogId, Result);
         Client := nil;
       finally
         ResponseBody.Free;

--- a/Dist/OpenApiIndy.pas
+++ b/Dist/OpenApiIndy.pas
@@ -50,6 +50,35 @@ type
 
 implementation
 
+//Interposer class
+//TZDecompressionStream does not support OwnsStream in XE4
+{$IF CompilerVersion < 26}      //XE4 or less
+type
+  TZDecompressionStream = class(ZLib.TZDecompressionStream)
+    private
+      FOwnsStream: Boolean;
+      FStream: TStream;
+    public
+      constructor Create(ASource: TStream; AWindowBits: Integer; AOwnsStream: Boolean); overload;
+      destructor Destroy; override;
+  end;
+
+constructor TZDecompressionStream.Create(ASource: TStream; AWindowBits: Integer; AOwnsStream: Boolean);
+begin
+  if AOwnsStream then
+    FStream := ASource;
+end;
+
+destructor TZDecompressionStream.Destroy;
+begin
+  if Assigned(FStream) then
+    FreeAndNil(FStream);
+end;
+
+{$ENDIF}
+
+
+
 { TIndyRestRequestFactory }
 
 function TIndyRestRequestFactory.CreateRequest: IRestRequest;

--- a/Dist/OpenApiRest.pas
+++ b/Dist/OpenApiRest.pas
@@ -13,6 +13,8 @@ uses
 type
   TCustomJsonConverter = OpenApiJson.TCustomJsonConverter;
 
+  IRestLogger = interface;
+
   IRestResponse = interface
   ['{C2CE5CD8-FA9F-442F-9980-988A2A0EFF3D}']
     function StatusCode: Integer;
@@ -25,6 +27,7 @@ type
   ['{55328D2F-FC30-48C7-9578-5A8A9152E4DA}']
     procedure SetUrl(const Url: string);
     procedure SetMethod(const Method: string);
+    procedure SetLogger(ALogger: IRestLogger);
     procedure AddQueryParam(const Name, Value: string);
     procedure AddUrlParam(const Name, Value: string);
     procedure AddHeader(const Name, Value: string);
@@ -37,6 +40,13 @@ type
     function CreateRequest: IRestRequest;
   end;
 
+  IRestLogger = interface
+  ['{7D368E9F-00AD-4D6B-A036-589BC6209B9B}']
+    /// This function may return an Id that is used in LogResponse to identify the request
+    function LogRequest(AMethod: string; AUrl: string; ARequestBody: TStringStream): string;
+    procedure LogResponse(AMethod: string; AUrl: string; ALogId: string; AResponse: IRestResponse);
+  end;
+
   TRestRequest = class(TInterfacedObject, IRestRequest)
   private
     FUrl: string;
@@ -45,17 +55,20 @@ type
     FUrlParams: TStrings;
     FHeaders: TStrings;
     FBody: string;
+    FLogger: IRestLogger;
   protected
     function BuildUrl: string;
     function PercentEncode(const Value: string): string; virtual;
     property Body: string read FBody;
     property Method: string read FMethod;
     property Headers: TStrings read FHeaders;
+    property Logger: IRestLogger read FLogger;
   public
     constructor Create;
     destructor Destroy; override;
     procedure SetUrl(const Url: string);
     procedure SetMethod(const HttpMethod: string);
+    procedure SetLogger(ALogger: IRestLogger);
     procedure AddHeader(const Name, Value: string);
     procedure AddQueryParam(const Name, Value: string); virtual;
     procedure AddUrlParam(const Name, Value: string); virtual;
@@ -79,10 +92,13 @@ type
     procedure SetBaseUrl(const Value: string);
     function GetRequestFactory: IRestRequestFactory;
     procedure SetRequestFactory(const Value: IRestRequestFactory);
+    function GetLogger: IRestLogger;
+    procedure SetLogger(const Value: IRestLogger);
 
     property BaseUrl: string read GetBaseUrl write SetBaseUrl;
     property AccessToken: string read GetAccessToken write SetAccessToken;
     property RequestFactory: IRestRequestFactory read GetRequestFactory write SetRequestFactory;
+    property Logger: IRestLogger read GetLogger write SetLogger;
   end;
 
   TCustomRestConfig = class(TInterfacedObject, IRestConfig)
@@ -90,17 +106,21 @@ type
     FBaseUrl: string;
     FAccessToken: string;
     FRequestFactory: IRestRequestFactory;
+    FLogger: IRestLogger;
     function GetAccessToken: string;
     function GetBaseUrl: string;
     procedure SetAccessToken(const Value: string);
     procedure SetBaseUrl(const Value: string);
     function GetRequestFactory: IRestRequestFactory;
     procedure SetRequestFactory(const Value: IRestRequestFactory);
+    function GetLogger: IRestLogger;
+    procedure SetLogger(const Value: IRestLogger);
   public
     constructor Create;
     property BaseUrl: string read GetBaseUrl write SetBaseUrl;
     property AccessToken: string read GetAccessToken write SetAccessToken;
     property RequestFactory: IRestRequestFactory read GetRequestFactory write SetRequestFactory;
+    property Logger: IRestLogger read GetLogger write SetLogger;
   end;
 
   TCustomRestService = class(TInterfacedObject)
@@ -265,6 +285,8 @@ begin
   Result.SetMethod(HttpMethod);
   if Config.AccessToken <> '' then
     Result.AddHeader('Authorization', 'Bearer ' + Config.AccessToken);
+  if Assigned(Config.Logger) then
+    Result.SetLogger(Config.Logger);
 end;
 
 destructor TCustomRestService.Destroy;
@@ -363,6 +385,12 @@ begin
   FUrl := Url;
 end;
 
+procedure TRestRequest.SetLogger(ALogger: IRestLogger);
+begin
+  FLogger := ALogger;
+end;
+
+
 { EOpenApiClientException }
 
 constructor EOpenApiClientException.Create(const Msg: string; Response: IRestResponse);
@@ -396,6 +424,11 @@ begin
   Result := FBaseUrl;
 end;
 
+function TCustomRestConfig.GetLogger: IRestLogger;
+begin
+  Result := FLogger;
+end;
+
 function TCustomRestConfig.GetRequestFactory: IRestRequestFactory;
 begin
   Result := FRequestFactory;
@@ -409,6 +442,11 @@ end;
 procedure TCustomRestConfig.SetBaseUrl(const Value: string);
 begin
   FBaseUrl := Value;
+end;
+
+procedure TCustomRestConfig.SetLogger(const Value: IRestLogger);
+begin
+  FLogger := Value;
 end;
 
 procedure TCustomRestConfig.SetRequestFactory(const Value: IRestRequestFactory);


### PR DESCRIPTION
XE4 does not support OwnsStream for TZDecompressionStream. The interposer class fixes this without touching the original code.