### PR TITLE
JSON values are not correctly escaped (issue #34): Fix for XE4 (DBXJSON)

### DIFF
--- a/Dist/OpenApiJson.pas
+++ b/Dist/OpenApiJson.pas
@@ -335,11 +335,23 @@ begin
 end;
 
 function TJsonWrapper.JsonValueToJson(Value: TJSONValue): string;
+{$IFDEF USEDBX}
+var
+  JsonBytes: TBytes;
+{$ENDIF}
 begin
 {$IFDEF FPC}
   Result := Value.AsJSON;
 {$ELSE}
-  Result := Value.ToString;
+  {$IFDEF USEDBX}
+    //Result := Value.ToString; does not correctly escape values  (eg \)
+    //see discussion here https://stackoverflow.com/questions/77623475/how-to-convert-tjsonstring-into-string-containing-json
+    SetLength(JsonBytes, Value.EstimatedByteSize);
+    SetLength(JsonBytes, Value.ToBytes(JsonBytes, 0));      //ToBytes escapes all real unicode characters which is unnecessary
+    Result := TEncoding.UTF8.GetString(JsonBytes);          //but this is reverted here
+  {$ELSE}
+    Result := Value.ToString;
+  {$ENDIF}
 {$ENDIF}
 end;
 


### PR DESCRIPTION
This is a fix for issue #34 for the XE4 version.

I am not sure, if the normal version is also affected. At the moment I have no Delphi version to test this.

From what I am reading [here](http://docwiki.embarcadero.com/RADStudio/Alexandria/en/JSON) Delphi versions <10.3 might need a fix too.

