### PR TITLE
Add support for all of schema

### DIFF
--- a/Source/OpenApiGen.Metadata.pas
+++ b/Source/OpenApiGen.Metadata.pas
@@ -123,6 +123,7 @@ type
     function GetHasValuePropName: string;
     function GetIsNullable: Boolean;
   public
+    function Clone: TMetaProperty;
     property FieldName: string read FFieldName write FFieldName;
     property PropName: string read FPropName write FPropName;
     property RestName: string read FRestName write FRestName;
@@ -523,6 +524,26 @@ begin
 end;
 
 { TMetaProperty }
+
+function TMetaProperty.Clone: TMetaProperty;
+var
+  lProperty: TMetaProperty;
+begin
+  lProperty := TMetaProperty.Create;
+  try
+    lProperty.FFieldName := FFieldName;
+    lProperty.FPropName := FPropName;
+    lProperty.FPropType := FPropType;
+    lProperty.FRestName := FRestName;
+    lProperty.FRequired := FRequired;
+    lProperty.FDescription := FDescription;
+
+    Result := lProperty;
+    lProperty := nil;
+  finally
+    lProperty.Free;
+  end;
+end;
 
 function TMetaProperty.GetIsNullable: Boolean;
 begin

--- a/Source/OpenApiGen.V2.Analyzer.pas
+++ b/Source/OpenApiGen.V2.Analyzer.pas
@@ -125,7 +125,7 @@ begin
           ResponseType := TargetResponseType
         else
         if ResponseType.TypeName <> TargetResponseType.TypeName then
-          raise EOpenApiAnalyzerException.CreateFmt('Ambiguous response types: %s and %s', [ResponseType.TypeName, TargetResponseType.TypeName]);
+          Logger.Warning(string.Format('Ambiguous response types for %s: %s and %s', [Operation.OperationId, ResponseType.TypeName, TargetResponseType.TypeName]));
       end;
     Method.ReturnType := ResponseType;
     if (ResponseType <> nil) and not ResponseType.IsBinary then

--- a/Source/OpenApiGen.V3.Analyzer.pas
+++ b/Source/OpenApiGen.V3.Analyzer.pas
@@ -147,7 +147,7 @@ begin
                 ResponseType := TargetResponseType
               else
               if ResponseType.TypeName <> TargetResponseType.TypeName then
-                raise EOpenApiAnalyzerException.CreateFmt('Ambiguous response types: %s and %s', [ResponseType.TypeName, TargetResponseType.TypeName]);
+                Logger.Warning(string.Format('Ambiguous response types for %s: %s and %s', [Operation.OperationId, ResponseType.TypeName, TargetResponseType.TypeName]))
             end;
       end;
     Method.ReturnType := ResponseType;


### PR DESCRIPTION
I added support for allOf schemas. They are now treated in the way, that the created object is a collection of the properties of all its subschemas.